### PR TITLE
Fix QScrollArea import

### DIFF
--- a/borderframe/image_processor.py
+++ b/borderframe/image_processor.py
@@ -1,5 +1,20 @@
 from PyQt5.QtWidgets import (
-    QMainWindow, QPushButton, QFileDialog, QVBoxLayout, QHBoxLayout, QWidget, QLabel, QComboBox, QSlider, QColorDialog, QLineEdit, QFrame, QCheckBox, QProgressDialog, QMessageBox
+    QMainWindow,
+    QPushButton,
+    QFileDialog,
+    QVBoxLayout,
+    QHBoxLayout,
+    QWidget,
+    QLabel,
+    QComboBox,
+    QSlider,
+    QColorDialog,
+    QLineEdit,
+    QFrame,
+    QCheckBox,
+    QProgressDialog,
+    QMessageBox,
+    QScrollArea,
 )
 from PyQt5.QtCore import Qt, QSize
 from PyQt5.QtGui import QPixmap, QPainter, QColor, QIntValidator, QFont

--- a/tests/test_calculate_dimensions.py
+++ b/tests/test_calculate_dimensions.py
@@ -32,6 +32,7 @@ sys.modules['PyQt5.QtGui'] = qtgui
 pil_module = types.ModuleType('PIL')
 sys.modules['PIL'] = pil_module
 sys.modules['PIL.Image'] = types.ModuleType('PIL.Image')
+sys.modules['PIL.ImageOps'] = types.ModuleType('PIL.ImageOps')
 exif_tags = types.ModuleType('PIL.ExifTags')
 exif_tags.TAGS = {}
 sys.modules['PIL.ExifTags'] = exif_tags


### PR DESCRIPTION
## Summary
- add QScrollArea to imports in `image_processor`
- stub PIL.ImageOps in tests for reliability

## Testing
- `PYTHONPATH=. python tests/test_calculate_dimensions.py`