### PR TITLE
Fix dark theme combobox popup text

### DIFF
--- a/borderframe/image_processor.py
+++ b/borderframe/image_processor.py
@@ -111,6 +111,10 @@ class ImageProcessor(QMainWindow):
                 background-color: #34495e;
                 color: #ecf0f1;
             }
+            QComboBox QAbstractItemView {
+                background-color: #34495e;
+                color: #ecf0f1;
+            }
             QSlider::groove:horizontal {
                 border: 1px solid #7f8c8d;
                 height: 8px;


### PR DESCRIPTION
## Summary
- ensure combo box popup items are styled for dark theme

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*