### PR TITLE
Add resolution-scaled borders

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@
   - 9:16 (Story)
   - 2:1 (Banner)
 - Border customization:
-  - Adjustable border size (0-300 pixels)
+  - Adjustable border size (0-300 pixels). The value entered is scaled
+    per image so that the perceived width stays consistent across
+    different resolutions.
 - Custom color picker
 - Live preview of changes
 - Optional dark or light theme (choice persists across sessions)
@@ -87,3 +89,5 @@ python main.py
 - Memory-efficient processing allows for large batches of images
 - The ``BORDERFRAME_WORKERS`` environment variable can limit the
   number of concurrent worker threads during processing
+- Border width is scaled using ``scaled = int(user_px * min(width, height) /``
+  ``1000)`` and the resulting value is displayed next to the slider

--- a/borderframe/process_worker.py
+++ b/borderframe/process_worker.py
@@ -4,7 +4,7 @@ import piexif
 import os
 import concurrent.futures
 
-from .utils import calculate_dimensions
+from .utils import calculate_dimensions, BASE_SIZE
 
 
 class ProcessWorker(QThread):
@@ -72,7 +72,7 @@ class ProcessWorker(QThread):
                 return None
             base_filename = self.settings['base_filename']
             aspect_ratio = self.settings['aspect_ratio']
-            border_size = self.settings['border_size']
+            user_border_px = self.settings['user_border_px']
             save_format = self.settings['save_format']
             quality = self.settings['quality']
             preserve_metadata = self.settings['preserve_metadata']
@@ -93,12 +93,18 @@ class ProcessWorker(QThread):
                     img = img.convert('RGB')
 
                 orig_width, orig_height = img.size
+                scaled_border = int(
+                    user_border_px * min(orig_width, orig_height) / BASE_SIZE
+                )
                 target_width, target_height = calculate_dimensions(
-                    orig_width, orig_height, border_size, aspect_ratio
+                    orig_width,
+                    orig_height,
+                    scaled_border,
+                    aspect_ratio,
                 )
 
-                if border_size > 0:
-                    img = ImageOps.expand(img, border=border_size, fill=border_color)
+                if scaled_border > 0:
+                    img = ImageOps.expand(img, border=scaled_border, fill=border_color)
 
                 current_width, current_height = img.size
                 if (target_width, target_height) != (current_width, current_height):

--- a/borderframe/utils.py
+++ b/borderframe/utils.py
@@ -5,6 +5,10 @@ from typing import Optional, Tuple
 from PIL import Image, ImageOps
 from PyQt5.QtGui import QPixmap, QImage
 
+# Base size used for scaling the user provided border width. This keeps
+# borders visually consistent across images of different resolutions.
+BASE_SIZE = 1000
+
 try:  # Pillow < 10
     from PIL.ImageQt import ImageQt  # type: ignore
     _HAS_IMAGEQT = True
@@ -13,8 +17,23 @@ except Exception:  # pragma: no cover - fallback for newer Pillow versions
     _HAS_IMAGEQT = False
 
 
-def calculate_dimensions(img_width: int, img_height: int, border_size: int, aspect_ratio: Optional[Tuple[int, int]]):
-    """Calculate new dimensions for adding a border while respecting an optional aspect ratio."""
+def calculate_dimensions(
+    img_width: int,
+    img_height: int,
+    border_size: int,
+    aspect_ratio: Optional[Tuple[int, int]],
+    user_px: Optional[int] = None,
+) -> Tuple[int, int]:
+    """Calculate new dimensions for adding a border while respecting an optional
+    aspect ratio.
+
+    If ``user_px`` is provided, it is scaled to an actual border width using
+    ``BASE_SIZE`` so borders have a consistent appearance regardless of the
+    image resolution.
+    """
+
+    if user_px is not None:
+        border_size = int(user_px * min(img_width, img_height) / BASE_SIZE)
     if aspect_ratio is None:
         new_width = img_width + (border_size * 2)
         new_height = img_height + (border_size * 2)

--- a/tests/test_calculate_dimensions.py
+++ b/tests/test_calculate_dimensions.py
@@ -43,6 +43,7 @@ sys.modules['piexif'] = types.ModuleType('piexif')
 sys.modules['numpy'] = types.ModuleType('numpy')
 
 from borderframe.image_processor import ImageProcessor
+from borderframe.utils import BASE_SIZE
 
 
 def get_processor():
@@ -73,3 +74,15 @@ def test_four_by_five_ratio_various_size():
     assert (width1, height1) == (820, 1025)
     width2, height2 = proc.calculate_dimensions(100, 200, 0, (4, 5))
     assert (width2, height2) == (160, 200)
+
+
+def test_scaled_border_rule():
+    proc = get_processor()
+    user_px = 21
+    width, height = proc.calculate_dimensions(7728, 5152, user_px, None, user_px)
+    expected_border = int(user_px * min(7728, 5152) / BASE_SIZE)
+    assert expected_border == 108
+    assert (width, height) == (
+        7728 + expected_border * 2,
+        5152 + expected_border * 2,
+    )


### PR DESCRIPTION
## Summary
- add `BASE_SIZE` constant and support scaling in `calculate_dimensions`
- display scaled width in the UI and expose user pixel value to workers
- compute scaled border inside processing worker
- add a unit test exercising the scaling rule
- document scaling behaviour in README

## Testing
- `python -m py_compile borderframe/utils.py borderframe/image_processor.py borderframe/process_worker.py tests/test_calculate_dimensions.py`
- `python -m pytest -q` *(fails: No module named 'pytest')*