### PR TITLE
Update docs for pillow-simd

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
 ```bash
 pip install -r requirements.txt
 ```
+4. Advanced users may install `pillow-simd` instead of `Pillow` for improved performance
 
 ## Usage
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 PyQt5>=5.15.0
-Pillow>=9.0.0
+Pillow>=9.0.0  # advanced users can install pillow-simd instead for better performance
 piexif>=1.1.3
 pillow-heif>=0.10.0


### PR DESCRIPTION
## Summary
- note that pillow-simd can replace Pillow in `requirements.txt`
- update README installation instructions mentioning pillow-simd

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*